### PR TITLE
Don't hide single labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,7 @@ color for the header text
 ### Background Colors
 
 If this card has a label, then the background color will be based on the color
-of the first label. If you only have one label, then that label will be hidden,
-otherwise you'll still be able to see all the labels displayed.
+of the first label.
 
 ## Development TODO:
 

--- a/src/content.scss
+++ b/src/content.scss
@@ -23,10 +23,6 @@ $black: #355263;
       opacity: 0.7;
     }
 
-    .list-card-labels, .list-card-title {
-      display: none !important;
-    }
-
     .enhanced-header-text {
       display: block;
       text-align: center;

--- a/src/content.scss
+++ b/src/content.scss
@@ -23,6 +23,10 @@ $black: #355263;
       opacity: 0.7;
     }
 
+    .list-card-title {
+      display: none !important;
+    }
+
     .enhanced-header-text {
       display: block;
       text-align: center;

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Visual Enhancements for Trello",
-  "version": "1.0.0.2",
+  "version": "1.0.1.0",
   "description": "Background colours and headers for Trello cards",
   "manifest_version": 2,
   "icons": {


### PR DESCRIPTION
## Why

Many boards use multiple labels with different text but the same color, which are hard to identify when using this extension. Additionally, this extension has recently been floated as a replacement for "Card Colors for Trello", which always shows all labels.

## Other

I wasn't sure which versioning scheme you're using so I took a guess at the value to increment for feature changes.